### PR TITLE
[BUGFIX] Update VimeoImageService with Code from TYPO3 11.5.8 VimeoHe…

### DIFF
--- a/Classes/Service/VimeoImageService.php
+++ b/Classes/Service/VimeoImageService.php
@@ -15,7 +15,7 @@ class VimeoImageService
     /**
      * @var string
      */
-    protected $apiUri = 'https://vimeo.com/api/v2/video/###ID###.json';
+    protected $apiUri = 'https://vimeo.com/api/oembed.json?width=2048&url=https%3A%2F%2Fvimeo.com%2F###ID###';
 
     /**
      * @var ExtensionConfiguration
@@ -48,9 +48,8 @@ class VimeoImageService
                 $response = $this->requestFactory->request($uri);
                 if ($response->getStatusCode() === 200) {
                     $json = json_decode($response->getBody()->getContents(), true);
-                    if (!empty($json[0]['thumbnail_large']) || !empty($json[0]['thumbnail_medium']) || !empty($json[0]['thumbnail_small'])) {
-                        $thumbnailUri = $json[0]['thumbnail_large'] ?: $json[0]['thumbnail_medium'] ?: $json[0]['thumbnail_small'];
-                        $thumbnailResponse = $this->requestFactory->request($thumbnailUri);
+                    if (!empty($json['thumbnail_url'])) {
+                        $thumbnailResponse = $this->requestFactory->request($json['thumbnail_url']);
                         if ($thumbnailResponse->getStatusCode() === 200) {
                             GeneralUtility::writeFileToTypo3tempDir($filename, $thumbnailResponse->getBody()->getContents());
                             $fileExists = true;


### PR DESCRIPTION
Hi Nicole,

Vimeo seems to have changed the API URL, so no more preview images could be fetched for the videos.
With this PR I have adapted the URL, which is also used by the [TYPO3 core](https://github.com/TYPO3/typo3/blob/9763ce5287afbaa8b07d2651a94c624ea296a298/typo3/sysext/core/Classes/Resource/OnlineMedia/Helpers/VimeoHelper.php#L97) itself. 