### PR TITLE
Adapt YouTube preview names to current core settings

### DIFF
--- a/Classes/Service/YoutubeImageService.php
+++ b/Classes/Service/YoutubeImageService.php
@@ -24,6 +24,7 @@ class YoutubeImageService implements PreviewImageServiceInterface
         'maxresdefault.jpg',
         'sddefault.jpg',
         'hqdefault.jpg',
+        'mqdefault.jpg',
         '0.jpg',
     ];
 


### PR DESCRIPTION
'mqdefault.jpg' was missing on our side.