### PR TITLE
Allow umap URLs for openstreetmap

### DIFF
--- a/Classes/Handler/OpenStreetMapHandler.php
+++ b/Classes/Handler/OpenStreetMapHandler.php
@@ -33,7 +33,7 @@ class OpenStreetMapHandler implements HandlerInterface
     public function hasMatches(string $content): bool
     {
         preg_match_all(
-            '/<iframe(?:(?: src="(?:(?:https?:)?\/\/)?(?:www\.)?openstreetmap\.org\/export\/embed.html\?bbox=(?<bbox>[^&]+)[^"]*?"| height="(?<height>[^"]+)"| width="(?<width>[^"]+)"|(?!src)[^>])+)>.*?<\/iframe>/i',
+            '/<iframe(?:(?: src="(?:(?:https?:)?\/\/)?(?:(?:www|umap)\.)?openstreetmap\.(?:org|de|fr)\/(?:export\/embed.html\?bbox=(?<bbox>[^&]+)|[a-z]{2}\/map\/)[^"]*?"| height="(?<height>[^"]+)"| width="(?<width>[^"]+)"|(?!src)[^>])+)>.*?<\/iframe>/i',
             $content,
             $this->matches,
             PREG_SET_ORDER


### PR DESCRIPTION
I changed the regular expression to also match umap URLs like https://umap.openstreetmap.fr/de/map/.*
This change also allows height and width attributes before and after the src attribute.